### PR TITLE
feat(rules) Improve `required-tags` rule.

### DIFF
--- a/changelog/required-tags.md
+++ b/changelog/required-tags.md
@@ -1,0 +1,7 @@
+### Changed
+* Improve `required-tags` rule.
+  * Add options to set required tags for each level.
+  * Add option to define global tags, to be defined on any level.
+  * Add options to extend rule and example tags to Scenario when that levels are not present for that Scenario.
+  * Deprecated the `tags` options, should be replaced by `scenario`.
+  * Improved tag checks allowing to force an expression is a RegExp (should be wrapped between slashes), and matching tag completely on string match.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "9.1.3",
     "mocha-sinon": "2.1.2",
     "mock-fs": "5.1.1",
+    "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
     "sinon": "11.1.2"
   },
@@ -53,7 +54,8 @@
     "lint": "eslint ./src ./test",
     "mocha": "mocha --recursive",
     "prepare": "npm run build",
-    "test": "npm run lint && npm run build && nyc -include=dist/** npm run mocha"
+    "test": "run-s -c -n lint build test:unit",
+    "test:unit": "nyc -include=dist/** npm run mocha"
   },
   "directories": {
     "lib": "./src",

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -1,25 +1,21 @@
 const _ = require('lodash');
 const gherkinUtils = require('./utils/gherkin.js');
 
-const rule = 'required-tags';
+const name = 'required-tags';
 const availableConfigs = {
-  tags: [],
-  ignoreUntagged: true
+  ignoreUntagged: true,
+  tags: [], // Deprecated
+  global: [],
+  feature: [],
+  rule: [],
+  scenario: [],
+  example: [],
+  extendRule: false,
+  extendExample: false,
 };
 
-
-function checkTagExists(requiredTag, ignoreUntagged, scenarioTags, scenarioType, scenarioLocation) {
-  const result = (ignoreUntagged && scenarioTags.length == 0)
-    || scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
-  if (!result) {
-    return {
-      message: `No tag found matching ${requiredTag} for ${scenarioType}`,
-      rule,
-      line: scenarioLocation.line,
-      column: scenarioLocation.column,
-    };
-  }
-  return result;
+function reduceGlobals(globalTags, {tags}) {
+  return globalTags.filter(t => !tags.map(ft => ft.name).includes(t));
 }
 
 function run({feature}, config) {
@@ -30,28 +26,85 @@ function run({feature}, config) {
   const mergedConfig = _.merge({}, availableConfigs, config);
 
   let errors = [];
-  feature.children.forEach((child) => {
-    if (child.scenario) {
-      const type = gherkinUtils.getNodeType(child.scenario, feature.language);
-      const location = child.scenario.location;
+  const legacyTagsCheck = mergedConfig.tags.length > 0 && mergedConfig.scenario.length === 0;
+  if (legacyTagsCheck) {
+    mergedConfig.scenario = mergedConfig.tags;
+  }
 
-      // Check each Scenario for the required tags
-      const requiredTagErrors = mergedConfig.tags
-        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig.ignoreUntagged, child.scenario.tags || [], type, location))
-        .filter((item) =>
-          typeof item === 'object' && item.message
-        );
-
-      // Update errors
-      errors = errors.concat(requiredTagErrors);
+  function checkRequiredTags(item, requiredTags, extraRequiredTags = [], useLegacyCheck = false) {
+    if (mergedConfig.ignoreUntagged && item.tags.length === 0) {
+      return;
     }
-  });
+
+    const allRequiredTags = requiredTags.concat(extraRequiredTags);
+
+    const missTags = allRequiredTags.filter(requiredTag => !item.tags.some(tag => {
+      const regexpMatch = requiredTag.match(/^@?\/(?<exp>.*)\/$/);
+      if (useLegacyCheck) {
+        return RegExp(requiredTag).test(tag.name);
+      } else {
+        return regexpMatch ? RegExp(regexpMatch.groups.exp).test(tag.name) : requiredTag === tag.name;
+      }
+    }));
+    if (missTags.length > 0) {
+      errors.push(createError(item, missTags, feature.language));
+    }
+  }
+
+  checkRequiredTags(feature, mergedConfig.feature);
+  function iterScenarioContainer(item, globalTags, insideRule = false) {
+    const globalContainerTags = reduceGlobals(globalTags, item);
+
+    for (const {rule, scenario} of item.children) {
+      if (!insideRule && rule != null) {
+        checkRequiredTags(rule, mergedConfig.rule);
+
+        iterScenarioContainer(rule, globalContainerTags, true);
+      } else if (scenario != null) {
+        let globalScenarioTags = reduceGlobals(globalContainerTags, scenario);
+        const globalScenarioTagsAux = globalScenarioTags;
+        const scenarioExtendedTags = [];
+
+        if (mergedConfig.extendRule && !insideRule) {
+          scenarioExtendedTags.push(...mergedConfig.rule);
+        }
+
+        if (mergedConfig.extendExample && scenario.examples.length === 0) {
+          scenarioExtendedTags.push(...mergedConfig.example);
+        }
+
+        if (scenario.examples.length !== 0) {
+          for (const example of scenario.examples) {
+            globalScenarioTags = reduceGlobals(globalScenarioTagsAux, example);
+            checkRequiredTags(example, mergedConfig.example);
+          }
+        }
+
+        scenarioExtendedTags.push(...globalScenarioTags);
+
+        checkRequiredTags(scenario, mergedConfig.scenario, scenarioExtendedTags, legacyTagsCheck);
+      }
+    }
+  }
+
+  iterScenarioContainer(feature, mergedConfig.global);
 
   return errors;
 }
 
+function createError(item, requiredTags, lang) {
+  const type = gherkinUtils.getNodeType(item, lang);
+
+  return {
+    message: `The tag(s) [${requiredTags}] should be present for ${type}.`,
+    rule: name,
+    line: item.location.line,
+    column: item.location.column,
+  };
+}
+
 module.exports = {
-  name: rule,
+  name,
   run: run,
   availableConfigs: availableConfigs
 };

--- a/test/rules/required-tags/NoViolations.feature
+++ b/test/rules/required-tags/NoViolations.feature
@@ -1,28 +1,87 @@
-@featuretag
+@feature
+@required-global-tag-feature
+@required-tag-feature
 Feature: Feature with all of the required tags present
 
-Background:
-  Given I have a Background
+  Background:
+    Given I have a Background
 
-@requiredscenariotag @required-scenario-tag @required-scenario-tag-1234
-Scenario: This is a Scenario with all of the required tags present
-  Then I should not see an error
+  @scenario
+  @required-tag-scenario @required-tag-scenario-1234
+  @required-global-tag-scenario
+  # Tags from rule as this scenario is not inside rule
+  @required-tag-rule-on-scenario @required-global-tag-rule
+  # Tags from example as this scenario is not inside and outline
+  @required-tag-example-on-scenario @required-global-tag-example
+  Scenario: This is a Scenario with all of the required tags present
+    Then I should not see an error
 
-@requiredscenariotag @required-scenario-tag @required-scenario-tag-5678
-Scenario Outline: This is a Scenario Outline with all of the required tags present
-  Then I should not see an error
+  @scenarioOutline
+  @required-tag-scenario @required-tag-scenario-4567
+  @required-global-tag-scenario
+  # Tags from rule as this scenario is not inside rule
+  @required-tag-rule-on-scenario
+  @required-global-tag-rule
+  Scenario Outline: This is a Scenario Outline with all of the required tags present
+    Then I should not see an error
+    @example
+    @required-tag-example
+    @required-global-tag-example
+    # Tags from scenario extend from example as this scenario is an outline
+    @required-tag-example-on-scenario
+    Examples:
+      | foo |
+      | bar |
 
-Examples:
-  | foo |
-  | bar |
+  Scenario: This is a Scenario with all of the required tags present
+    Then I should not see an error
 
+  Scenario Outline: This is a Scenario Outline with all of the required tags present
+    Then I should not see an error
 
-Scenario: This is a Scenario with all of the required tags present
-  Then I should not see an error
+    Examples:
+      | foo |
+      | bar |
 
-Scenario Outline: This is a Scenario Outline with all of the required tags present
-  Then I should not see an error
+  @rule @required-tag-rule
+  @required-global-tag-rule
+  # Tags from scenario extend from rule as this is a rule
+  @required-tag-rule-on-scenario
+  Rule: A rule
 
-Examples:
-  | foo |
-  | bar |
+    @scenario
+    @required-tag-scenario @required-tag-scenario-1234
+    @required-tag-example-on-scenario
+    @required-global-tag-scenario @required-global-tag-example
+
+    @scenario
+    @required-tag-scenario @required-tag-scenario-1234
+    @required-global-tag-scenario
+    # Tags from example as this scenario is not inside and outline
+    @required-tag-example-on-scenario @required-global-tag-example
+    Scenario: This is a Scenario inside rule with all of the required tags present
+      Then I should not see an error
+
+    @scenarioOutline
+    @required-tag-scenario @required-tag-scenario-4567
+    @required-global-tag-scenario
+    @required-global-tag-rule
+    Scenario Outline: This is a Scenario Outline inside rule with all of the required tags present
+      Then I should not see an error
+      @example @required-tag-example
+      @required-global-tag-example
+      # Tags from scenario extend from example as this scenario is an outline
+      @required-tag-example-on-scenario
+      Examples:
+        | foo |
+        | bar |
+
+    Scenario: This is a Scenario inside rule with all of the required tags present
+      Then I should not see an error
+
+    Scenario Outline: This is a Scenario Outline inside rule with all of the required tags present
+      Then I should not see an error
+
+      Examples:
+        | foo |
+        | bar |

--- a/test/rules/required-tags/Violations.feature
+++ b/test/rules/required-tags/Violations.feature
@@ -1,24 +1,52 @@
-@featuretag
+@feature
 Feature: Feature with some of the required tags missing
 
-Background:
-  Given I have a Background
+  Background:
+    Given I have a Background
 
-@requiredscenariotag @required-scenario-tag-ABCD-1234
-Scenario: This is a Scenario with some of the required tags missing
-  Then I should see an error
+  @scenario @required-tag-scenario-untag
+  Scenario: This is a Scenario with some of the required tags missing
+      Then I should see an error
 
-@requiredscenariotag @required-scenario-tag-ABCD-1234
-@unrequired-tag-on-a-new-line
-Scenario Outline: This is a Scenario Outline with some of the required tags missing
-  Then I should see an error
+  @scenarioOutline @required-tag-scenario-untag
+  Scenario Outline: This is a Scenario Outline with some of the required tags missing
+      Then I should see an error
+    @example
+    Examples:
+      | foo |
+      | bar |
 
-Examples:
-  | foo |
-  | bar |
+  Scenario: This is a Scenario with some of the required tags missing
+      Then I should see an error
 
-Scenario: This is a Scenario that has no tag
-  Then I should see an error
+  Scenario Outline: This is a Scenario Outline with some of the required tags missing
+      Then I should see an error
 
-Scenario Outline: This is a Scenario Outline that has no tag
-  Then I should see an error
+    Examples:
+      | foo |
+      | bar |
+
+  @rule
+  Rule: A rule
+
+    @scenario @required-tag-scenario-untag
+    Scenario: This is a Scenario inside rule with some of the required tags missing
+        Then I should see an error
+
+    @scenarioOutline @required-tag-scenario-untag
+    Scenario Outline: This is a Scenario Outline inside rule with some of the required tags missing
+        Then I should see an error
+      @example
+      Examples:
+        | foo |
+        | bar |
+
+    Scenario: This is a Scenario inside rule with some of the required tags missing
+        Then I should see an error
+
+    Scenario Outline: This is a Scenario Outline inside rule with some of the required tags missing
+        Then I should see an error
+
+      Examples:
+        | foo |
+        | bar |

--- a/test/rules/required-tags/ViolationsUntagged.feature
+++ b/test/rules/required-tags/ViolationsUntagged.feature
@@ -1,0 +1,25 @@
+Feature: Feature without tags
+
+  Background:
+    Given I have a Background
+
+  Scenario: This is a Scenario without tags
+      Then I should see an error
+
+  Scenario Outline: This is a Scenario Outline without tags
+      Then I should see an error
+    Examples:
+      | foo |
+      | bar |
+
+  Rule: A rule
+
+    Scenario: This is a Scenario inside rule without tags
+        Then I should see an error
+
+    Scenario Outline: This is a Scenario Outline inside rule without tags
+        Then I should see an error
+
+      Examples:
+        | foo |
+        | bar |

--- a/test/rules/required-tags/deprecated/NoViolations.feature
+++ b/test/rules/required-tags/deprecated/NoViolations.feature
@@ -1,0 +1,28 @@
+@featuretag
+Feature: Feature with all of the required tags present
+
+Background:
+  Given I have a Background
+
+@requiredscenariotag @required-scenario-tag @required-scenario-tag-1234
+Scenario: This is a Scenario with all of the required tags present
+  Then I should not see an error
+
+@requiredscenariotag @required-scenario-tag @required-scenario-tag-5678
+Scenario Outline: This is a Scenario Outline with all of the required tags present
+  Then I should not see an error
+
+Examples:
+  | foo |
+  | bar |
+
+
+Scenario: This is a Scenario with all of the required tags present
+  Then I should not see an error
+
+Scenario Outline: This is a Scenario Outline with all of the required tags present
+  Then I should not see an error
+
+Examples:
+  | foo |
+  | bar |

--- a/test/rules/required-tags/deprecated/Violations.feature
+++ b/test/rules/required-tags/deprecated/Violations.feature
@@ -1,0 +1,24 @@
+@featuretag
+Feature: Feature with some of the required tags missing
+
+Background:
+  Given I have a Background
+
+@requiredscenariotag @required-scenario-tag-ABCD-1234
+Scenario: This is a Scenario with some of the required tags missing
+  Then I should see an error
+
+@requiredscenariotag @required-scenario-tag-ABCD-1234
+@unrequired-tag-on-a-new-line
+Scenario Outline: This is a Scenario Outline with some of the required tags missing
+  Then I should see an error
+
+Examples:
+  | foo |
+  | bar |
+
+Scenario: This is a Scenario that has no tag
+  Then I should see an error
+
+Scenario Outline: This is a Scenario Outline that has no tag
+  Then I should see an error

--- a/test/rules/required-tags/deprecated/required-tags.js
+++ b/test/rules/required-tags/deprecated/required-tags.js
@@ -1,0 +1,38 @@
+var ruleTestBase = require('../../rule-test-base');
+var rule = require('../../../../dist/rules/required-tags.js');
+var runTest = ruleTestBase.createRuleTest(rule, 'The tag(s) [<%= tags %>] should be present for <%= nodeType %>.');
+
+describe('Required Tags Rule - Deprecated', function() {
+  it('doesn\'t raise errors when there are no violations', function() {
+    return runTest('required-tags/deprecated/NoViolations.feature', {
+      'tags': ['@requiredscenariotag', '@required-scenario-tag', '@required-scenario-tag-\\d+']
+    }, []);
+  });
+  it('detects errors for scenarios and scenario outlines', () => {
+    return runTest('required-tags/deprecated/Violations.feature', {
+      'tags': ['@requiredscenariotag', '@requiredScenarioTag', '@required-scenario-tag-\\d+']
+    }, [{
+      messageElements: {tags: ['@requiredScenarioTag','@required-scenario-tag-\\d+'], nodeType: 'Scenario'},
+      line: 8,
+      column: 1,
+    }, {
+      messageElements: {tags: ['@requiredScenarioTag', '@required-scenario-tag-\\d+'], nodeType: 'Scenario Outline'},
+      line: 13,
+      column: 1,
+    }]);
+  });
+  it('detects errors for scenarios and scenario outlines that have no tag', () => {
+    return runTest('required-tags/deprecated/Violations.feature', {
+      'tags': ['@requiredscenariotag'],
+      'ignoreUntagged': false
+    }, [{
+      messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario'},
+      line: 20,
+      column: 1,
+    }, {
+      messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario Outline'},
+      line: 23,
+      column: 1,
+    }]);
+  });
+});

--- a/test/rules/required-tags/required-tags.js
+++ b/test/rules/required-tags/required-tags.js
@@ -1,46 +1,297 @@
-var ruleTestBase = require('../rule-test-base');
-var rule = require('../../../dist/rules/required-tags.js');
-var runTest = ruleTestBase.createRuleTest(rule, 'No tag found matching <%= tags %> for <%= nodeType %>');
+const ruleTestBase = require('../rule-test-base');
+const rule = require('../../../dist/rules/required-tags.js');
+const runTest = ruleTestBase.createRuleTest(rule, 'The tag(s) [<%= tags %>] should be present for <%= nodeType %>.');
 
-describe('Required Tags Rule', function() {
-  it('doesn\'t raise errors when there are no violations', function() {
-    return runTest('required-tags/NoViolations.feature', {
-      'tags': ['@requiredscenariotag', '@required-scenario-tag', '@required-scenario-tag-\\d+']
-    }, []);
+describe('Required Tags Rule', function () {
+  describe('no errors', function () {
+    it('doesn\'t raise errors when there are no violations', function () {
+      return runTest('required-tags/NoViolations.feature', {
+        ignoreUntagged: true,
+        global: ['@required-global-tag-feature', '@required-global-tag-rule', '@required-global-tag-scenario', '@required-global-tag-example'],
+        feature: ['@required-tag-feature'],
+        rule: ['@required-tag-rule'],
+        scenario: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'],
+        example: ['@required-tag-example'],
+        extendRule: false,
+        extendExample: false,
+      }, []);
+    });
+
+    describe('extend', function () {
+      it('rule to scenario', function () {
+        return runTest('required-tags/NoViolations.feature', {
+          ignoreUntagged: true,
+          rule: ['@required-tag-rule-on-scenario'],
+          extendRule: true,
+          extendExample: false,
+        }, []);
+      });
+
+      it('example to scenario', function () {
+        return runTest('required-tags/NoViolations.feature', {
+          ignoreUntagged: true,
+          example: ['@required-tag-example-on-scenario'],
+          extendRule: false,
+          extendExample: true,
+        }, []);
+      });
+    });
   });
-  it('detects errors for scenarios and scenario outlines', () => {
-    return runTest('required-tags/Violations.feature', {
-      'tags': ['@requiredscenariotag', '@requiredScenarioTag', '@required-scenario-tag-\\d+']
-    }, [{
-      messageElements: {tags: '@requiredScenarioTag', nodeType: 'Scenario'},
-      line: 8,
-      column: 1,
-    }, {
-      messageElements: {tags: '@requiredScenarioTag', nodeType: 'Scenario Outline'},
-      line: 13,
-      column: 1,
-    }, {
-      messageElements: {tags: '@required-scenario-tag-\\d+', nodeType: 'Scenario'},
-      line: 8,
-      column: 1,
-    }, {
-      messageElements: {tags: '@required-scenario-tag-\\d+', nodeType: 'Scenario Outline'},
-      line: 13,
-      column: 1,
-    }]);
-  });
-  it('detects errors for scenarios and scenario outlines that have no tag', () => {
-    return runTest('required-tags/Violations.feature', {
-      'tags': ['@requiredscenariotag'],
-      'ignoreUntagged': false
-    }, [{
-      messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario'},
-      line: 20,
-      column: 1,
-    }, {
-      messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario Outline'},
-      line: 23,
-      column: 1,
-    }]);
+
+  describe('detect errors', function () {
+    it('feature', function () {
+      return runTest('required-tags/Violations.feature', {
+        ignoreUntagged: true,
+        feature: ['@required-tag-feature'],
+      }, [{
+        messageElements: {tags: '@required-tag-feature', nodeType: 'Feature'},
+        line: 2,
+        column: 1,
+      }]);
+    });
+
+    it('rule', function () {
+      return runTest('required-tags/Violations.feature', {
+        ignoreUntagged: true,
+        rule: ['@required-tag-rule'],
+      }, [{
+        messageElements: {tags: '@required-tag-rule', nodeType: 'Rule'},
+        line: 30,
+        column: 3,
+      }]);
+    });
+
+    it('scenario', function () {
+      return runTest('required-tags/Violations.feature', {
+        ignoreUntagged: true,
+        scenario: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'],
+      }, [{
+        messageElements: {tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario'},
+        line: 8,
+        column: 3,
+      }, {
+        messageElements: {
+          tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario Outline'
+        },
+        line: 12,
+        column: 3,
+      }, {
+        messageElements: {tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario'},
+        line: 33,
+        column: 5,
+      }, {
+        messageElements: {
+          tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario Outline'
+        },
+        line: 37,
+        column: 5,
+      }]);
+    });
+
+    it('example', function () {
+      return runTest('required-tags/Violations.feature', {
+        ignoreUntagged: true,
+        example: ['@required-tag-example'],
+      }, [{
+        messageElements: {tags: '@required-tag-example', nodeType: 'Examples'},
+        line: 15,
+        column: 5,
+      }, {
+        messageElements: {tags: '@required-tag-example', nodeType: 'Examples'},
+        line: 40,
+        column: 7,
+      }]);
+    });
+
+    describe('extend', function () {
+      it('rule to scenario', function () {
+        return runTest('required-tags/Violations.feature', {
+          ignoreUntagged: true,
+          rule: ['@required-tag-rule-on-scenario'],
+          scenario: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'],
+          extendRule: true,
+        }, [{
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/', '@required-tag-rule-on-scenario'],
+            nodeType: 'Scenario'
+          },
+          line: 8,
+          column: 3,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/', '@required-tag-rule-on-scenario'],
+            nodeType: 'Scenario Outline'
+          },
+          line: 12,
+          column: 3,
+        }, {
+          messageElements: {tags: '@required-tag-rule-on-scenario', nodeType: 'Rule'},
+          line: 30,
+          column: 3,
+        }, {
+          messageElements: {tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario'},
+          line: 33,
+          column: 5,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario Outline'
+          },
+          line: 37,
+          column: 5,
+        }]);
+      });
+
+      it('example to scenario', function () {
+        return runTest('required-tags/Violations.feature', {
+          ignoreUntagged: true,
+          scenario: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'],
+          example: ['@required-tag-example-on-scenario'],
+          extendExample: true,
+        }, [{
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/', '@required-tag-example-on-scenario'],
+            nodeType: 'Scenario'
+          },
+          line: 8,
+          column: 3,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario Outline'
+          },
+          line: 12,
+          column: 3,
+        }, {
+          messageElements: {tags: '@required-tag-example-on-scenario', nodeType: 'Examples'},
+          line: 15,
+          column: 5,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/', '@required-tag-example-on-scenario'],
+            nodeType: 'Scenario'
+          },
+          line: 33,
+          column: 5,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-scenario', '/@required-tag-scenario-\\d+/'], nodeType: 'Scenario Outline'
+          },
+          line: 37,
+          column: 5,
+        }, {
+          messageElements: {tags: '@required-tag-example-on-scenario', nodeType: 'Examples'},
+          line: 40,
+          column: 7,
+        }]);
+      });
+
+      it('example and rule to scenario', function () {
+        return runTest('required-tags/Violations.feature', {
+          ignoreUntagged: true,
+          rule: ['@required-tag-rule-on-scenario'],
+          example: ['@required-tag-example-on-scenario'],
+          extendRule: true,
+          extendExample: true,
+        }, [{
+          messageElements: {
+            tags: ['@required-tag-rule-on-scenario', '@required-tag-example-on-scenario'], nodeType: 'Scenario'
+          },
+          line: 8,
+          column: 3,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-rule-on-scenario'], nodeType: 'Scenario Outline'
+          },
+          line: 12,
+          column: 3,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-example-on-scenario'], nodeType: 'Examples'
+          },
+          line: 15,
+          column: 5,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-rule-on-scenario'], nodeType: 'Rule'
+          },
+          line: 30,
+          column: 3,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-example-on-scenario'], nodeType: 'Scenario'
+          },
+          line: 33,
+          column: 5,
+        }, {
+          messageElements: {
+            tags: ['@required-tag-example-on-scenario'], nodeType: 'Examples'
+          },
+          line: 40,
+          column: 7,
+        },]);
+      });
+    });
+
+    describe('include untagged', function () {
+      it('feature', function () {
+        return runTest('required-tags/ViolationsUntagged.feature', {
+          ignoreUntagged: false,
+          feature: ['@required-tag-feature'],
+        }, [{
+          messageElements: {tags: '@required-tag-feature', nodeType: 'Feature'},
+          line: 1,
+          column: 1,
+        }]);
+      });
+
+      it('rule', function () {
+        return runTest('required-tags/ViolationsUntagged.feature', {
+          ignoreUntagged: false,
+          rule: ['@required-tag-rule'],
+        }, [{
+          messageElements: {tags: '@required-tag-rule', nodeType: 'Rule'},
+          line: 15,
+          column: 3,
+        }]);
+      });
+
+      it('scenario', function () {
+        return runTest('required-tags/ViolationsUntagged.feature', {
+          ignoreUntagged: false,
+          scenario: ['@required-tag-scenario'],
+        }, [{
+          messageElements: {tags: '@required-tag-scenario', nodeType: 'Scenario'},
+          line: 6,
+          column: 3,
+        }, {
+          messageElements: {tags: '@required-tag-scenario', nodeType: 'Scenario Outline'},
+          line: 9,
+          column: 3,
+        }, {
+          messageElements: {tags: '@required-tag-scenario', nodeType: 'Scenario'},
+          line: 17,
+          column: 5,
+        }, {
+          messageElements: {tags: '@required-tag-scenario', nodeType: 'Scenario Outline'},
+          line: 20,
+          column: 5,
+        }]);
+      });
+
+      it('example', function () {
+        return runTest('required-tags/ViolationsUntagged.feature', {
+          ignoreUntagged: false,
+          example: ['@required-tag-example'],
+        }, [{
+          messageElements: {tags: '@required-tag-example', nodeType: 'Examples'},
+          line: 11,
+          column: 5,
+        }, {
+          messageElements: {tags: '@required-tag-example', nodeType: 'Examples'},
+          line: 23,
+          column: 7,
+        }
+        ]);
+      });
+    });
   });
 });


### PR DESCRIPTION
  * Add options to set required tags for each level.
  * Add option to define global tags, to be defined on any level.
  * Add options to extend rule and example tags to Scenario when that levels are not present for that Scenario.
  * Deprecated the `tags` options, should be replaced by `scenario`.
  * Improved tag checks allowing to force an expression is a RegExp (should be wrapped between slashes), and matching tag completely on string match.

chore(package.json) Improve test scripts