### PR TITLE
fix() Fix load default config file if argument is not specified.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const options = program.opts() as CliOptions;
 const additionalRulesDirs = options.rulesdir;
 const files = featureFinder.getFeatureFiles(program.args, options.ignore);
 
-linter.lint(files, options.config, additionalRulesDirs)
+linter.lintInit(files, options.config, additionalRulesDirs)
   .then(async (results) => {
     await printResults(results, options.format);
     process.exit(getExitCode(results, options));

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -12,6 +12,7 @@ import {
   GherkinError,
   RuleError,
   RuleErrorLevel,
+  RulesConfig,
 } from './types';
 import * as configParser from './config-parser';
 
@@ -68,11 +69,13 @@ export function readAndParseFile(filePath: string): Promise<GherkinData> {
   });
 }
 
-export async function lint(files: string[], configPath?: string, additionalRulesDirs?: string[]): Promise<ErrorsByFile[]> {
-  const configuration = configPath ? await configParser.getConfiguration(configPath, additionalRulesDirs) : {};
+export async function lintInit(files: string[], configPath?: string, additionalRulesDirs?: string[]): Promise<ErrorsByFile[]> {
+  const configuration = await configParser.getConfiguration(configPath, additionalRulesDirs);
+  return lint(files, configuration, additionalRulesDirs);
+}
 
+export function lint(files: string[], configuration?: RulesConfig, additionalRulesDirs?: string[]): Promise<ErrorsByFile[]> {
   const results = [] as ErrorsByFile[];
-
   return Promise.all(files.map((f) => {
     let perFileErrors = [] as RuleError[];
 

--- a/test/linter/linter.ts
+++ b/test/linter/linter.ts
@@ -3,7 +3,7 @@ import * as linter from '../../src/linter';
 import {RuleError} from '../../src';
 
 async function linterTest(feature: string, expected: RuleError[]) {
-  const actual = await linter.lint([feature]);
+  const actual = await linter.lint([feature], {});
   assert.lengthOf(actual, 1);
   assert.deepEqual(actual[0].errors, expected);
 }

--- a/test/rulesdir/rulesdir.ts
+++ b/test/rulesdir/rulesdir.ts
@@ -9,7 +9,7 @@ describe('rulesdir CLI option', function() {
       path.join('test', 'rulesdir', 'other_rules') // relative path from root
     ];
     const featureFile = path.join(__dirname, 'simple.feature');
-    return linter.lint([ featureFile ], path.join(__dirname, '.gplintrc'), additionalRulesDirs)
+    return linter.lintInit([ featureFile ], path.join(__dirname, '.gplintrc'), additionalRulesDirs)
       .then((results) => {
         expect(results).to.deep.equal([
           {


### PR DESCRIPTION
This bug was introduced on #434