### PR TITLE
chore() Drop Node 12 support support

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - run: npm i
       - run: npm test
 
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: npm i
       - run: npm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        node-version: [12, 14, 16, 18, 19]
+        node-version: [14, 16, 18, 20.4]
         architecture:
           - x64
     name: Node ${{ matrix.node-version }} - ${{ matrix.architecture }} on ${{ matrix.os }}

--- a/.npm-upgrade.json
+++ b/.npm-upgrade.json
@@ -1,0 +1,32 @@
+{
+  "ignore": {
+    "chalk": {
+      "versions": ">4",
+      "reason": "From v5 requires ESM support"
+    },
+    "commander": {
+      "versions": ">10",
+      "reason": "From v11 requires Node 16"
+    },
+    "glob": {
+      "versions": ">8",
+      "reason": "From v9 requires Node 16"
+    },
+    "strip-ansi": {
+      "versions": ">6",
+      "reason": "From v7 requires ESM support"
+    },
+    "strip-json-comments": {
+      "versions": ">3",
+      "reason": "From v4 requires ESM support"
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "versions": ">5",
+      "reason": "From v6 requires Node 16"
+    },
+    "@typescript-eslint/parser": {
+      "versions": ">5",
+      "reason": "From v6 requires Node 16"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "glob": "8.1.0",
     "lodash": "4.17.21",
     "strip-ansi": "6.0.1",
-    "strip-json-comments": "3.0.1",
+    "strip-json-comments": "3.1.1",
     "text-table": "0.2.0",
     "ts-node": "10.9.1",
     "xml-js": "1.6.11"
@@ -70,11 +70,11 @@
     "@types/lodash": "4.14.199",
     "@types/mocha": "10.0.2",
     "@types/mock-fs": "4.13.2",
-    "@types/node": "^20.1.0",
-    "@types/sinon": "10.0.16",
+    "@types/node": "^20.8.2",
+    "@types/sinon": "10.0.18",
     "@types/sinon-chai": "3.2.10",
     "@types/text-table": "0.2.3",
-    "@typescript-eslint/eslint-plugin": "5.61.0",
+    "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "chai": "4.3.10",
     "coveralls": "3.1.1",
@@ -84,12 +84,12 @@
     "mock-fs": "5.2.0",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
-    "sinon": "15.2.0",
+    "sinon": "16.1.0",
     "sinon-chai": "3.7.0",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "directories": {
     "lib": "./src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES6",
+    "target": "ES2020",
     "lib": [
-      "ES2021"
+      "ES2020"
     ],
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
Minimum Node version is now 14 (which is used to create the package), and add tests with Node 20. Also update some dependencies